### PR TITLE
Fix zh-classical wikicode for lzh language

### DIFF
--- a/numberof.awk
+++ b/numberof.awk
@@ -114,6 +114,7 @@ function dataconfig(datac,  a,i,s,sn,jsona,configfp,language,site,status,countof
 
           if(language == "be-x-old") language = "be-tarask"
           else if(language == "gsw") language = "als"
+          else if(language == "lzh") language = "zh-classical"
           else if(language == "rup") language = "roa-rup"
           else if(language == "sgs") language = "bat-smg"
           else if(language == "vro") language = "fiu-vro"


### PR DESCRIPTION
Currently, the result table has "lzh" as wikicode, instead of "zh-classical".

See:
- https://commons.wikimedia.org/wiki/Data:Wikipedia_statistics/data.tab
- https://meta.wikimedia.org/wiki/Template:List_of_wikis_by_project