### PR TITLE
Fix zh-min-nan wikicode for nan language

### DIFF
--- a/numberof.awk
+++ b/numberof.awk
@@ -115,6 +115,7 @@ function dataconfig(datac,  a,i,s,sn,jsona,configfp,language,site,status,countof
           if(language == "be-x-old") language = "be-tarask"
           else if(language == "gsw") language = "als"
           else if(language == "lzh") language = "zh-classical"
+          else if(language == "nan") language = "zh-min-nan"
           else if(language == "rup") language = "roa-rup"
           else if(language == "sgs") language = "bat-smg"
           else if(language == "vro") language = "fiu-vro"


### PR DESCRIPTION
Currently, the result table has "nan" as wikicode, instead of "zh-min-nan".